### PR TITLE
Add missing define for compiler needs.

### DIFF
--- a/common/hid_LINUX.c
+++ b/common/hid_LINUX.c
@@ -28,6 +28,8 @@
  * Version 1.0: Initial Release
  */
 
+#define PATH_MAX 4096
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
Add missing PATH_MAX definition missing in Fedora 34 and possibly other distributions.